### PR TITLE
Record which system was presented first in AB and ABX results

### DIFF
--- a/listen_and_rate/routers/api/ab.py
+++ b/listen_and_rate/routers/api/ab.py
@@ -63,6 +63,10 @@ def _submit_ab(body: SubmitRequest, config: ABConfig, saver: ResultSaver) -> dic
             {
                 "system_a": system_a,
                 "system_b": system_b,
+                # The system whose clip was presented first (as "A" on screen).
+                # `stimulus_ids` arrives in presentation order; without this
+                # column a position bias is invisible in the results.
+                "presented_first": meta1["system"],
                 "item": meta1["item"],
                 "winner": winner,
                 **_metrics_row(choice, config),

--- a/listen_and_rate/routers/api/abx.py
+++ b/listen_and_rate/routers/api/abx.py
@@ -99,6 +99,8 @@ def _submit_abx(
             {
                 "system_a": system_a,
                 "system_b": system_b,
+                "presented_first": meta1["system"],
+                "x_matched": id_to_meta[ground_truth]["system"],
                 "item": meta1["item"],
                 "correct": choice.selected_stimulus_id == ground_truth,
                 **_metrics_row(choice, config),

--- a/tests/routers/api/test_ab.py
+++ b/tests/routers/api/test_ab.py
@@ -98,6 +98,7 @@ def test_ab_submit_happy_path_preference(tmp_path, test_audio_file, monkeypatch)
             "test_type",
             "system_a",
             "system_b",
+                "presented_first",
             "item",
             "winner",
         ]

--- a/tests/routers/api/test_abx.py
+++ b/tests/routers/api/test_abx.py
@@ -167,6 +167,8 @@ def test_abx_submit_scores_exactly_one_of_two_opposite_guesses_correct(
             "test_type",
             "system_a",
             "system_b",
+                "presented_first",
+                "x_matched",
             "item",
             "correct",
         ]


### PR DESCRIPTION
Trials shuffle the pair per listener, but the stored row keeps only the sorted system names and the winner. A listener who always picks the clip heard second is then indistinguishable from one with a real preference — which is exactly what happened in a session we ran: 10 of 14 "different" answers, all on the second-played side, only discoverable because we had the key on disk.

This adds one column to AB and ABX rows, `presented_first` — the system whose stimulus was shown as A (`stimulus_ids` arrives in presentation order) — and, for ABX, `x_matched`. Both are derived from data the server already has at submit time; no client change. Tests updated for the two new columns; the suite passes (579 passed, 23 skipped).

Happy to rename or move the columns if you'd prefer them under `metrics`.